### PR TITLE
Add Nphies integration roadmap documentation

### DIFF
--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -1,5 +1,7 @@
 # NPHIES Integration - Getting Started Guide
 
+> **Need a high-level roadmap?** See the companion [Nphies Integration Recommendations](./nphies_integration_recommendations.md) document for a strategic implementation checklist covering architecture, compliance, testing, and project planning.
+
 ## Quick Setup
 
 ### 1. Install Dependencies

--- a/docs/nphies_integration_recommendations.md
+++ b/docs/nphies_integration_recommendations.md
@@ -1,0 +1,56 @@
+# Nphies Integration Recommendations
+
+This document captures a high-level roadmap for integrating the GIVC platform with the Saudi Nphies unified health information platform. The recommendations are grouped into thematic areas so that engineering, product, and compliance stakeholders can plan implementation milestones.
+
+## 1. Adopt FHIR-Based Messaging
+
+* **Use a FHIR library:** Integrate a standards-compliant HL7 FHIR R4 SDK (for example, `fhir.resources` for Python or HAPI-FHIR for Java) to construct and validate resources programmatically.
+* **Implement message bundles:** Create helpers that assemble FHIR `Bundle` resources containing `MessageHeader` elements and the supporting resources (`Patient`, `Organization`, `Claim`, and others) required for each transaction type.
+* **Apply Nphies profiles:** Validate that all produced resources conform to the Nphies implementation guide. Do not include unsupported extensions or omit profile-mandated constraints.
+* **Populate Must-Support fields:** Add validation routines that ensure all Must-Support elements called out in the Nphies conformance guide are populated before transmission.
+
+## 2. Modular Service Architecture
+
+* **Separate transaction services:** Provide dedicated modules for Eligibility, Pre-Authorization, Advanced Authorization, Claim, Payment, Communication, Poll, Status, Cancellation, and Report transactions. Each module should build the appropriate FHIR `Bundle`, handle HTTPS communication with the Nphies APIs, and persist request/response logs for auditing.
+* **ETL layer:** Introduce an extraction, transformation, and load layer that maps GIVC domain models (e.g., EMR or billing records) into FHIR resources, such as `Claim` objects, to maintain a clean separation between internal data and interoperability payloads.
+
+## 3. Security and Compliance
+
+* **Authentication:** Implement OAuth 2.0 (or the authentication scheme mandated by Nphies) with support for token acquisition and refresh operations.
+* **Transport security:** Enforce HTTPS with TLS 1.2+ for all outbound calls. Store secrets—client IDs, client secrets, tokens—in secure configuration stores such as environment variables or a secrets manager.
+* **Data privacy:** Apply role-based access control to restrict integration functionality and record audit logs for all sensitive operations to support HIPAA/GDPR-equivalent compliance.
+
+## 4. Validation and Error Handling
+
+* **FHIR validation:** Integrate an automated validator that checks outgoing messages against Nphies profiles prior to submission.
+* **Error response processing:** Parse Nphies error responses to extract actionable remediation guidance (missing fields, invalid codes, and similar issues) for end users.
+* **Retry and de-duplication:** Implement retry policies for transient transport errors and safeguard against duplicate submissions.
+* **Denial management:** Persist denial reasons and expose remediation workflows—such as an administrative dashboard—to amend and resubmit claims.
+
+## 5. User Interface and Reporting
+
+* **Time filters:** Add UI widgets that mirror the Nphies portal, enabling start and end date filters for transaction views.
+* **Summary dashboard:** Provide a summary component displaying counts by transaction type, similar to the Transaction Viewer’s Summary section.
+* **Export and reporting:** Allow exports of transaction listings with user confirmation gates before exporting sensitive data.
+
+## 6. Testing and Deployment
+
+* **Integration testing:** Automate test suites that interact with a Nphies sandbox, verifying expected responses for every transaction type.
+* **Continuous integration:** Extend the CI pipeline to validate generated FHIR messages and run unit tests on pull requests.
+* **Performance monitoring:** Capture latency, throughput, and error-rate metrics, and configure alerting for sustained degradation.
+
+## 7. Documentation and Developer Support
+
+* **README updates:** Expand the main README with architectural descriptions, dependency details, and usage instructions covering the Nphies integration.
+* **Code comments:** Document functions that build FHIR bundles, execute API calls, and interpret responses to improve maintainability.
+* **Sample payloads:** Provide example JSON request and response payloads for eligibility checks, authorizations, claims, and payments.
+* **Training materials:** Create onboarding guides that outline FHIR basics, Nphies requirements, and internal development processes.
+
+## 8. Project Management
+
+* **Issues and tasks:** Create GitHub issues for each major initiative (e.g., FHIR library adoption, EligibilityService implementation, OAuth support) and assign owners.
+* **Milestones:** Define milestones such as MVP Integration, Security & Validation, and UI & Reporting to track progress and dependencies.
+
+---
+
+These recommendations provide a structured approach to delivering a compliant, maintainable, and user-focused Nphies integration for the GIVC platform.


### PR DESCRIPTION
## Summary
- add a dedicated Nphies integration recommendations document covering architecture, security, and project planning
- link the new roadmap from the existing getting started guide for quick discovery

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_690254ea72f88331a3ac892364b7568d